### PR TITLE
support for whisper method on private channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,21 +133,21 @@ wrapper.vm.$nextTick(() => {
 
 ## Client events
 
-You can use `userWhisper` to send user event. Only private channel object and presence channel object have `userWhisper`.
+You can use `whisper` to send user event. Only private channel object and presence channel object have `whisper`.
 
 > Note: If you are using `vue-test-utils`, call `$nextTick` before assertion.
 
 Example:
 ```javascript
 // private channel
-mockEcho.getPrivateChannel('meeting').userWhisper('meetingClicking', { username: username })
+mockEcho.getPrivateChannel('meeting').whisper('meetingClicking', { username: username })
 wrapper.vm.$nextTick(() => {
     expect(wrapper.find('.whisper-message').text()).toBe(`${username} is clicking the button`)
     done()
 })
 
 // presence channel
-mockEcho.getPresenceChannel('chat').userWhisper('chatClicking', { username: username })
+mockEcho.getPresenceChannel('chat').whisper('chatClicking', { username: username })
 wrapper.vm.$nextTick(() => {
     expect(wrapper.find('.whisper-message').text()).toBe(`${username} is clicking the button`)
     done()

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ class PrivateChannel extends Channel {
         this.notificationFn = null
     }
 
-    userWhisper (eventName, event) {
+    whisper (eventName, event) {
         if (typeof this.clientEvents[`client-${eventName}`] === 'undefined') {
             console.error(`Channel didn't listen to client event: ${eventName}`)
             return
@@ -55,10 +55,6 @@ class PrivateChannel extends Channel {
 
     notify (notifiable) {
         this.notificationFn(notifiable)
-    }
-
-    whisper(eventName, event) {
-        this.userWhisper(eventName, event);
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,10 @@ class PrivateChannel extends Channel {
     notify (notifiable) {
         this.notificationFn(notifiable)
     }
+
+    whisper(eventName, event) {
+        this.userWhisper(eventName, event);
+    }
 }
 
 class PresenceChannel extends PrivateChannel {


### PR DESCRIPTION
This simply proxies to the `userWhisper` function already in place.

A test I wrote that leverages this is:

```
it('it triggers a search when the connect button is clicked', () => {
        const mockChannel = mockEcho.private('foo');
        component = mount(Connector, {
            propsData: {
                channel: mockChannel
            }
        });
        let searchingCt = 0;
        mockChannel.listenForWhisper('searching', () => {
            ++searchingCt;
        });
        component.find('button').trigger('click');

        expect(searchingCt).toBe(1);
});
```

the component code calls the `whisper` method on its `channel` property to satisfy this test.